### PR TITLE
User関連更新

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,6 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :residence])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :residence, :profile_image])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,7 +5,19 @@ class UsersController < ApplicationController
   end
 
   def edit
-    @user = current_user
+    @user = User.find(params[:id])
+  end
+
+  def update
+    @user = User.find(params[:id])
+    @user.update(user_params)
+    redirect_to user_path(@user.id)
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email, :profile_image, :residence)
   end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,4 +4,8 @@ class UsersController < ApplicationController
     @user = current_user
   end
 
+  def edit
+    @user = current_user
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,7 @@ class User < ApplicationRecord
 
   has_many :murmurs, dependent: :destroy
   has_many :posts, dependent: :destroy
+  attachment :profile_image
 
   has_many :reverse_of_relationships, class_name: "Relationship", foreign_key: "followed_id", dependent: :destroy
   has_many :relationships, class_name: "Relationship", foreign_key: "follower_id", dependent: :destroy

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -4,6 +4,10 @@ h2
   = render "devise/shared/error_messages", resource: resource
 
   .field
+    = f.label :profile_image
+    br
+    = f.attachment_field :profile_image
+  .field
     = f.label :name
     br
     = f.text_field :name, autofocus: true, autocomplete: "name"

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -1,0 +1,2 @@
+h1 Users#edit
+p Find me in app/views/users/edit.html.slim

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -1,8 +1,7 @@
 h1 Users#edit
 p Find me in app/views/users/edit.html.slim
 
-= form_with model: @user, url: user_registration_path, id: 'new_user', class: 'new_user', local: true do |f|
-  = render "devise/shared/error_messages", resource: resource
+= form_with model: @user, url: user_path(@user.id), local: true do |f|
 
   .field
     = f.label :profile_image
@@ -19,19 +18,6 @@ p Find me in app/views/users/edit.html.slim
   .field
     = f.label :residence
     br
-    = f.select :residence, options_for_select(User.residences.keys)
-  .field
-    = f.label :password
-    - if @minimum_password_length
-      em
-        | (
-        = @minimum_password_length
-        |  characters minimum)
-    br
-    = f.password_field :password, autocomplete: "new-password"
-  .field
-    = f.label :password_confirmation
-    br
-    = f.password_field :password_confirmation, autocomplete: "new-password"
+    = f.select :residence, options_for_select(User.residences.keys, selected: @user.residence)
   .actions
-    = f.submit "Sign up"
+    = f.submit "Finish Edit"

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -1,2 +1,37 @@
 h1 Users#edit
 p Find me in app/views/users/edit.html.slim
+
+= form_with model: @user, url: user_registration_path, id: 'new_user', class: 'new_user', local: true do |f|
+  = render "devise/shared/error_messages", resource: resource
+
+  .field
+    = f.label :profile_image
+    br
+    = f.attachment_field :profile_image
+  .field
+    = f.label :name
+    br
+    = f.text_field :name, autofocus: true, autocomplete: "name"
+  .field
+    = f.label :email
+    br
+    = f.email_field :email, autofocus: true, autocomplete: "email"
+  .field
+    = f.label :residence
+    br
+    = f.select :residence, options_for_select(User.residences.keys)
+  .field
+    = f.label :password
+    - if @minimum_password_length
+      em
+        | (
+        = @minimum_password_length
+        |  characters minimum)
+    br
+    = f.password_field :password, autocomplete: "new-password"
+  .field
+    = f.label :password_confirmation
+    br
+    = f.password_field :password_confirmation, autocomplete: "new-password"
+  .actions
+    = f.submit "Sign up"

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -3,6 +3,8 @@ p Find me in app/views/users/show.html.slim
 
 p welcome #{@user.name} !
 
+= attachment_image_tag @user, :profile_image, :fill, 60, 60
+
 h2
   - if User.find(params[:id]) == current_user
     |Your page.

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -5,6 +5,10 @@ p welcome #{@user.name} !
 
 = attachment_image_tag @user, :profile_image, :fill, 60, 60
 
+br
+
+= link_to "プロフィールを編集する", edit_user_path(@user.id), class: "btn btn-success"
+
 h2
   - if User.find(params[:id]) == current_user
     |Your page.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   root to: 'homes#top'
 
-  resources :users, only: [:show] do
+  resources :users, only: [:show, :edit] do
     resources :murmurs, only: [:create, :destroy]
     resource :relationships, only: [:create, :destroy]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   root to: 'homes#top'
 
-  resources :users, only: [:show, :edit] do
+  resources :users, only: [:show, :edit, :update] do
     resources :murmurs, only: [:create, :destroy]
     resource :relationships, only: [:create, :destroy]
   end

--- a/db/migrate/20210107125428_add_image_id_to_users.rb
+++ b/db/migrate/20210107125428_add_image_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddImageIdToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :image_id, :text
+  end
+end

--- a/db/migrate/20210107125428_add_image_id_to_users.rb
+++ b/db/migrate/20210107125428_add_image_id_to_users.rb
@@ -1,5 +1,0 @@
-class AddImageIdToUsers < ActiveRecord::Migration[5.2]
-  def change
-    add_column :users, :image_id, :text
-  end
-end

--- a/db/migrate/20210108030144_add_profile_image_id_to_users.rb
+++ b/db/migrate/20210108030144_add_profile_image_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddProfileImageIdToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :profile_image_id, :text
+  end
+end

--- a/db/migrate/20210108030359_remove_image_id_from_users.rb
+++ b/db/migrate/20210108030359_remove_image_id_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveImageIdFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :image_id, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_07_053736) do
+ActiveRecord::Schema.define(version: 2021_01_08_030359) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string "namespace"
@@ -76,6 +76,7 @@ ActiveRecord::Schema.define(version: 2021_01_07_053736) do
     t.datetime "updated_at", null: false
     t.integer "residence", default: 0
     t.boolean "is_deleted", default: false
+    t.text "profile_image_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
- User関連の更新
  - usersテーブルにprofile_image_idカラムを追加している。(refileで管理する)
  - usersコントローラにeditとupdate処理を追加。同時にroutes.rbも変更し遷移できるように。
  - 新規登録時にも画像が登録できるようにした。