### PR TITLE
[Update] ユーザーページ更新

### DIFF
--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -2,12 +2,12 @@ class RelationshipsController < ApplicationController
 
   def create
     current_user.follow(params[:user_id])
-    redirect_to request.referer
+    @user = User.find(params[:user_id])
   end
 
   def destroy
     current_user.unfollow(params[:user_id])
-    redirect_to request.referer
+    @user = User.find(params[:user_id])
   end
 
 end

--- a/app/views/posts/edit.html.slim
+++ b/app/views/posts/edit.html.slim
@@ -25,7 +25,6 @@ p Find me in app/views/posts/edit.html.slim
   = f.text_field :impression
   br
   = f.submit 'Save'
-= render 'shared/star'
 
 javascript:
   $(function() {
@@ -37,6 +36,7 @@ javascript:
         starHalf: "#{asset_path('star-half.png')}",
         scoreName: 'post[rate]',
         half: true,
+        score: "#{@post.rate}",
       });
     }
   });

--- a/app/views/posts/new.html.slim
+++ b/app/views/posts/new.html.slim
@@ -25,7 +25,6 @@ p Find me in app/views/posts/new.html.slim
   = f.text_field :impression
   br
   = f.submit 'Go'
-= render 'shared/star'
 
 javascript:
   $(function() {

--- a/app/views/relationships/create.js.erb
+++ b/app/views/relationships/create.js.erb
@@ -1,0 +1,1 @@
+$("#follow").html("<%= j(render partial: 'shared/follow', locals: {user: @user}) %>");

--- a/app/views/relationships/destroy.js.erb
+++ b/app/views/relationships/destroy.js.erb
@@ -1,0 +1,1 @@
+$("#follow").html("<%= j(render partial: 'shared/follow', locals: {user: @user}) %>");

--- a/app/views/shared/_column.html.slim
+++ b/app/views/shared/_column.html.slim
@@ -9,6 +9,13 @@
       .d-flex.justify-content-between
         - if objects == @left_posts
           span #{count}位
+        - else
+          - if ((Time.now - post.created_at) / 60 ) >= 60
+            = ((Time.now - post.created_at) / 3600 ).round(0)
+            | 時間前
+          - else
+            = ((Time.now - post.created_at) / 60 ).round(0)
+            | 分前
         .d-flex.justify-content-between
           span.border
             | #{post.place}

--- a/app/views/shared/_follow.html.slim
+++ b/app/views/shared/_follow.html.slim
@@ -1,0 +1,4 @@
+- if current_user.following?(user)
+    = link_to "フォロー解除", user_relationships_path(user.id), method: :delete, remote: :true, class: "btn btn-primary btn-sm mt-2 btn-block"
+- else
+    = link_to "フォローする", user_relationships_path(user.id), method: :post, remote: :true, class: "btn btn-success btn-sm mt-2 btn-block"

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,9 +1,12 @@
 h3.text-center.mt-3
-  | マイページ
-.row
+  - if @user == current_user
+    | マイページ
+  - else
+    | #{@user.name}さんのページ
+.row.mt-3
   .col-sm-8.d-flex.justify-content-center.border
     .align-self-center
-      = attachment_image_tag current_user, :profile_image, size: "80x80", class: "border"
+      = attachment_image_tag current_user, :profile_image, size: "80x80", fallback: "no_image_user.jpg", class: "border"
     p.ml-3.align-self-center
       b style="font-size:1.5rem"
         | #{@user.name}
@@ -29,6 +32,62 @@ h3.text-center.mt-3
           = link_to "フォロー解除", user_relationships_path(@user.id), method: :delete, class: "btn btn-primary btn-sm mt-2 btn-block"
         - else
           = link_to "フォローする", user_relationships_path(@user.id), method: :post, class: "btn btn-success btn-sm mt-2 btn-block"
+.row.mt-3
+  .col-sm-6.border
+    - @user.murmurs.reverse.each do |murmur|
+      .border-bottom.text-break
+        = murmur.body
+        | &nbsp;
+        br
+        .d-flex.justify-content-between
+          u
+            - if ((Time.now - murmur.created_at) / 60 ) >= 60
+              = ((Time.now - murmur.created_at) / 3600 ).round(0)
+              | 時間前
+            - else
+              = ((Time.now - murmur.created_at) / 60 ).round(0)
+              | 分前
+          - if @user == current_user
+            = link_to "削除", user_murmur_path(@user.id, murmur.id), method: :delete, class:"btn btn-danger btn-sm"
+  .col-sm-6
+    .border-bottom
+      - @user.posts.reverse.each do |post|
+        .row
+          .mt-3.mx-1.mx-auto
+            .d-flex.justify-content-between
+              - if ((Time.now - post.created_at) / 60 ) >= 60
+                = ((Time.now - post.created_at) / 3600 ).round(0)
+                | 時間前
+              - else
+                = ((Time.now - post.created_at) / 60 ).round(0)
+                | 分前
+              .d-flex.justify-content-between
+                span.border
+                  | #{post.place}
+                span #{post.category}
+            = link_to(post_path(post.id)) do
+              = attachment_image_tag post, :image, width: "100%", fallback: "no_image_post.jpg"
+        .row
+            span id="star-usershow-ave-#{post.id}"
+        .row.border-bottom.justify-content-end
+            strong.mr-3
+              = link_to post.title, post_path(post.id)
+            javascript:
+              $(function() {
+                if((document.getElementById('star-usershow-ave-#{post.id}').getElementsByTagName("img").length == 0 )){
+                  // htmlのid="star-usershow-ave-#{post.id}"の部分を探し、その中のimgタグ(星の個数)を配列で返す => 配列の長さが0の場合、raty.jsを実行する。
+                  // 星の個数が0のときのみraty.jsが実行されるため、星が6個以上にはならなくなりレイアウトが崩れなくなる。
+                  $('#star-usershow-ave-#{post.id}').raty({
+                    size: 36,
+                    starOff: "#{asset_path('star-off.png')}",
+                    starOn: "#{asset_path('star-on.png')}",
+                    starHalf: "#{asset_path('star-half.png')}",
+                    half: true,
+                    readOnly: true,
+                    score: "#{post.avgrate}",
+                  });
+                }
+              });
 
 p other User page...
 

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -35,10 +35,8 @@ h3.text-center.mt-3
       - if @user == current_user
         = link_to "会員情報編集", edit_user_path(@user.id), class: "btn btn-success btn-sm mt-2 btn-block"
       - else
-        - if current_user.following?(@user)
-          = link_to "フォロー解除", user_relationships_path(@user.id), method: :delete, class: "btn btn-primary btn-sm mt-2 btn-block"
-        - else
-          = link_to "フォローする", user_relationships_path(@user.id), method: :post, class: "btn btn-success btn-sm mt-2 btn-block"
+        #follow
+          = render 'shared/follow', user: @user
 .row.mt-3
   .col-sm-6.border
     - @user.murmurs.reverse.each do |murmur|
@@ -107,16 +105,3 @@ h3.text-center.mt-3
           - else
             u
               | まだ投稿がないみたいです。
-
-
-p other User page...
-
-- User.all.each do |user|
-  = link_to user.name, user_path(user.id)
-  br
-
-p Posts
-
-- @user.posts.each do |post|
-  = link_to post.title, post_path(post.id)
-  br

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,46 +1,34 @@
-h1 Users#show
-p Find me in app/views/users/show.html.slim
+h3.text-center.mt-3
+  | マイページ
+.row
+  .col-sm-8.d-flex.justify-content-center.border
+    .align-self-center
+      = attachment_image_tag current_user, :profile_image, size: "80x80", class: "border"
+    p.ml-3.align-self-center
+      b style="font-size:1.5rem"
+        | #{@user.name}
+      | さん
+      br
+      | &nbsp;登録日：#{@user.created_at.strftime("%Y/%m/%d")}
+      br
+      | &nbsp;お住まい：#{@user.residence}
+      br
+      | &nbsp;
+      u
+        = link_to ">>#{@user.residence}の投稿を探す", posts_path(posts_category: "#{@user.residence}")
 
-- if @user == current_user
-  h4
-    |welcome #{current_user.name} !
-
-  = attachment_image_tag current_user, :profile_image, :fill, 30, 30
-
-  = link_to "プロフィールを編集する", edit_user_path(@user.id), class: "btn btn-success btn-sm"
-br
-
-table.table
-  thead
-    tr
-      th pic
-      th name
-      th residence
-      th
-        |
-        = link_to "following count:#{@user.followings.count}", followings_path(@user.id)
-      th
-        |
-        = link_to "follower count:#{@user.followers.count}", followers_path(@user.id)
-  tbody
-    tr
-      td
-        = attachment_image_tag @user, :profile_image, :fill, 20, 20
-      td #{@user.name}
-      td #{@user.residence}
-      td
-        - @user.followings.reverse.each do |following|
-          | #{following.name}
-          br
-      td
-        - @user.followers.reverse.each do |follower|
-          | #{follower.name}
-          br
-- if current_user.following?(@user)
-  = link_to "フォロー解除", user_relationships_path(@user.id), method: :delete, class: "btn btn-primary"
-- else
-  = link_to "フォローする", user_relationships_path(@user.id), method: :post, class: "btn btn-success"
-
+  .col-sm-4
+    .align-self-start
+      = link_to "フォロー数：#{@user.followings.count}", followings_path(@user.id), class: "btn btn-primary btn-sm btn-block"
+      = link_to "フォロワー数：#{@user.followers.count}", followers_path(@user.id), class: "btn btn-info btn-sm mt-2 btn-block"
+      = link_to "♡いいね数：#{@user.favorites.count}", posts_path(posts_category: "user-favorite"), class: "btn btn-danger btn-sm mt-2 btn-block"
+      - if @user == current_user
+        = link_to "会員情報編集", edit_user_path(@user.id), class: "btn btn-success btn-sm mt-2 btn-block"
+      - else
+        - if current_user.following?(@user)
+          = link_to "フォロー解除", user_relationships_path(@user.id), method: :delete, class: "btn btn-primary btn-sm mt-2 btn-block"
+        - else
+          = link_to "フォローする", user_relationships_path(@user.id), method: :post, class: "btn btn-success btn-sm mt-2 btn-block"
 
 p other User page...
 

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -17,8 +17,15 @@ h3.text-center.mt-3
       | &nbsp;お住まい：#{@user.residence}
       br
       | &nbsp;
-      u
-        = link_to ">>#{@user.residence}の投稿を探す", posts_path(posts_category: "#{@user.residence}")
+      - if @user.residence == "---"
+        = link_to edit_user_path(@user.id) do
+          u
+            | お住まいが未登録です。
+            br
+            | 登録はこちら
+      - else
+        u
+          = link_to ">>#{@user.residence}の投稿を探す", posts_path(posts_category: "#{@user.residence}")
 
   .col-sm-4
     .align-self-start
@@ -49,6 +56,9 @@ h3.text-center.mt-3
               | 分前
           - if @user == current_user
             = link_to "削除", user_murmur_path(@user.id, murmur.id), method: :delete, class:"btn btn-danger btn-sm"
+    - if @user.murmurs.blank?
+      u.text-justify
+        | まだつぶやきがないみたいです。
   .col-sm-6
     .border-bottom
       - @user.posts.reverse.each do |post|
@@ -71,7 +81,8 @@ h3.text-center.mt-3
             span id="star-usershow-ave-#{post.id}"
         .row.border-bottom.justify-content-end
             strong.mr-3
-              = link_to post.title, post_path(post.id)
+              u
+                = link_to post.title, post_path(post.id)
             javascript:
               $(function() {
                 if((document.getElementById('star-usershow-ave-#{post.id}').getElementsByTagName("img").length == 0 )){
@@ -88,6 +99,15 @@ h3.text-center.mt-3
                   });
                 }
               });
+      - if @user.posts.blank?
+        .border
+          - if @user == current_user
+            u
+              = link_to "まだ投稿がないみたいです。投稿してみませんか？", new_post_path
+          - else
+            u
+              | まだ投稿がないみたいです。
+
 
 p other User page...
 


### PR DESCRIPTION
- ユーザーページを更新しました。
  - 上部左カラム名前・登録日・住まい・住まいの投稿を探すを実装。
    - 住まいが登録されていない場合は、別の文を表示。
  - 上部右カラムフォロー数・フォロワー数・いいね数・フォローボタン/会員情報編集ボタンを表示。
    - フォロー数・フォロワー数を押すとそれぞれのページに
    - いいね数を押すといいねした投稿に
    - フォローするを押すとフォロー(非同期化)
  - 下部左カラムにはつぶやきを実装。
  - 下部右カラムには投稿一覧を実装。