### PR TITLE
[Update] ユーザーログインページの修正

### DIFF
--- a/app/assets/stylesheets/user_login.scss
+++ b/app/assets/stylesheets/user_login.scss
@@ -1,4 +1,4 @@
-.user-new-registration {
+.user-login {
   height: 100vh;
   h2 {
     transform: rotate(0.05deg);
@@ -9,5 +9,8 @@
     font-family: 'M PLUS Rounded 1c', sans-serif;
     transform: rotate(0.05deg);
   }
-
+  p {
+    border: 1px solid transparent;
+    border-radius: 0.25rem;
+  }
 }

--- a/app/assets/stylesheets/user_password_edit.scss
+++ b/app/assets/stylesheets/user_password_edit.scss
@@ -1,0 +1,12 @@
+.user-password-resetedit {
+  height: 100vh;
+  h2 {
+    transform: rotate(0.05deg);
+    width: 60%;
+    margin: 0 auto;
+  }
+  h2, p, td, span, .btn {
+    font-family: 'M PLUS Rounded 1c', sans-serif;
+    transform: rotate(0.05deg);
+  }
+}

--- a/app/assets/stylesheets/user_password_new.scss
+++ b/app/assets/stylesheets/user_password_new.scss
@@ -1,16 +1,12 @@
-.user-login {
+.user-password-resetnew {
   height: 100vh;
   h2 {
     transform: rotate(0.05deg);
     width: 60%;
     margin: 0 auto;
   }
-  h2, p, td, span, .btn, a{
+  h2, p, td, span, .btn {
     font-family: 'M PLUS Rounded 1c', sans-serif;
     transform: rotate(0.05deg);
-  }
-  p {
-    border: 1px solid transparent;
-    border-radius: 0.25rem;
   }
 }

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Users::PasswordsController < Devise::PasswordsController
-  before_action :check_guest, only: :create
 
   # GET /resource/password/new
   # def new

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,6 +2,7 @@
 
 class Users::SessionsController < Devise::SessionsController
   before_action :authenticate_user!
+  before_action :reject_user, only: [:create]
   # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in
@@ -29,8 +30,17 @@ class Users::SessionsController < Devise::SessionsController
     user_path(current_user.id)
   end
 
-  # protected
+  protected
 
+  # 退会後のユーザーログイン阻止
+  def reject_user
+    @user = User.find_by(email: params[:user][:email].downcase)
+    if @user
+      if (@user.valid_password?(params[:user][:password]) && (@user.active_for_authentication? == false))
+        redirect_to new_user_session_path
+      end
+    end
+  end
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -3,7 +3,7 @@ class ContactMailer < ApplicationMailer
     @contact = contact
     mail(
       to:  ENV['GMAIL_ID'],
-      subject: 'お問い合わせ通知'
+      subject: "【IlluminatioNeon】問い合わせ通知"
     )
   end
 end

--- a/app/mailers/unsubscribe_mailer.rb
+++ b/app/mailers/unsubscribe_mailer.rb
@@ -3,7 +3,7 @@ class UnsubscribeMailer < ApplicationMailer
     @user = user
     mail(
       to:  ENV['GMAIL_ID'],
-      subject: '退会通知'
+      subject: "【IlluminatioNeon】退会通知"
     )
   end
 end

--- a/app/views/devise/mailer/reset_password_instructions.html.slim
+++ b/app/views/devise/mailer/reset_password_instructions.html.slim
@@ -1,12 +1,10 @@
 p
-  | Hello 
+  | Hello
   = @resource.email
   | !
 p
-  | Someone has requested a link to change your password. You can do this through the link below.
+  | パスワード発行の申請が行われました。
 p
   = link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token)
 p
-  | If you didn't request this, please ignore this email.
-p
-  | Your password won't change until you access the link above and create a new one.
+  | もしもこのメールに心当たりがなければ、無視して下さい。

--- a/app/views/devise/passwords/edit.html.slim
+++ b/app/views/devise/passwords/edit.html.slim
@@ -4,7 +4,7 @@
   p.mt-2.text-center.text-light
     | お手数おかけしますが、
     | 新しいパスワードを入力して下さい。
-  = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
+  = form_with model: @user, url: user_password_path, method: :put, local: true do |f|
     table.table.table-borderless.mt-3
       tbody
         tr
@@ -25,4 +25,5 @@
           i.fas.fa-exclamation-triangle
           |#{flash[:alert]}
     .row.justify-content-center
+      = f.hidden_field :reset_password_token
       = f.submit "パスワード変更完了", class: "btn btn-lg btn-outline-light"

--- a/app/views/devise/passwords/edit.html.slim
+++ b/app/views/devise/passwords/edit.html.slim
@@ -1,22 +1,28 @@
 .user-password-resetedit
-  h2
-    | Change your password
+  h2.mt-3.text-center.text-light.rounded-pill.border.border-light
+    | パスワード再発行画面
+  p.mt-2.text-center.text-light
+    | お手数おかけしますが、
+    | 新しいパスワードを入力して下さい。
   = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
-    = render "devise/shared/error_messages", resource: resource
-    = f.hidden_field :reset_password_token
-    .field
-      = f.label :password, "New password"
-      br
-      - if @minimum_password_length
-        em
-          | (
-          = @minimum_password_length
-          |  characters minimum)
-        br
-      = f.password_field :password, autofocus: true, autocomplete: "new-password"
-    .field
-      = f.label :password_confirmation, "Confirm new password"
-      br
-      = f.password_field :password_confirmation, autocomplete: "new-password"
-    .actions
-      = f.submit "Change my password"
+    table.table.table-borderless.mt-3
+      tbody
+        tr
+          td.align-middle
+            span.text-light
+              |新しいパスワード(6文字以上)
+          td
+            = f.password_field :password, autofocus: true, autocomplete: "new-password", class:"form-control"
+        tr
+          td.align-middle
+            span.text-light
+              |新しいパスワード(再入力)
+          td
+            = f.password_field :password_confirmation, autocomplete: "new-password", class:"form-control"
+    .row.justify-content-center
+      - if flash[:alert]
+        p.alert-info
+          i.fas.fa-exclamation-triangle
+          |#{flash[:alert]}
+    .row.justify-content-center
+      = f.submit "パスワード変更完了", class: "btn btn-lg btn-outline-light"

--- a/app/views/devise/passwords/edit.html.slim
+++ b/app/views/devise/passwords/edit.html.slim
@@ -1,22 +1,22 @@
-h2
-  | Change your password
-= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  = f.hidden_field :reset_password_token
-  .field
-    = f.label :password, "New password"
-    br
-    - if @minimum_password_length
-      em
-        | (
-        = @minimum_password_length
-        |  characters minimum)
+.user-password-resetedit
+  h2
+    | Change your password
+  = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
+    = render "devise/shared/error_messages", resource: resource
+    = f.hidden_field :reset_password_token
+    .field
+      = f.label :password, "New password"
       br
-    = f.password_field :password, autofocus: true, autocomplete: "new-password"
-  .field
-    = f.label :password_confirmation, "Confirm new password"
-    br
-    = f.password_field :password_confirmation, autocomplete: "new-password"
-  .actions
-    = f.submit "Change my password"
-= render "devise/shared/links"
+      - if @minimum_password_length
+        em
+          | (
+          = @minimum_password_length
+          |  characters minimum)
+        br
+      = f.password_field :password, autofocus: true, autocomplete: "new-password"
+    .field
+      = f.label :password_confirmation, "Confirm new password"
+      br
+      = f.password_field :password_confirmation, autocomplete: "new-password"
+    .actions
+      = f.submit "Change my password"

--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -1,11 +1,18 @@
-h2
-  | Forgot your password?
-= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :email
+.user-password-resetnew
+  h2.mt-3.text-center.text-light.rounded-pill.border.border-light
+    | パスワード再発行手続き
+  p.mt-2.text-center.text-light
+    | パスワードをお忘れですか？
     br
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  .actions
-    = f.submit "Send me reset password instructions"
-= render "devise/shared/links"
+    | 登録したメールアドレスにパスワード再発行メールをお送りします。
+  = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+    table.table.table-borderless.mt-3
+      tbody
+        tr
+          td.align-middle
+            span.text-light
+              |メールアドレス
+          td
+            = f.email_field :email, autofocus: true, autocomplete: "email", class:"form-control"
+    .row.justify-content-center
+      = f.submit "メール送信", class: "btn btn-lg btn-outline-light"

--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -5,7 +5,7 @@
     | パスワードをお忘れですか？
     br
     | 登録したメールアドレスにパスワード再発行メールをお送りします。
-  = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+  = form_with model: @user, url: user_password_path, local: true do |f|
     table.table.table-borderless.mt-3
       tbody
         tr

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -47,6 +47,6 @@
           td
             = f.password_field :password_confirmation, autocomplete: "new-password", class:"form-control"
     .row.justify-content-center
-      = f.submit "会員登録", class: "btn btn-bg btn-success"
+      = f.submit "会員登録", class: "btn btn-lg btn-outline-warning"
 
 = render 'shared/img_preview'

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -21,5 +21,6 @@
         p.alert-info
           i.fas.fa-exclamation-triangle
           |#{flash[:alert]}
+          |#{flash[:error]}
     .row.justify-content-center
       = f.submit "ログイン", class: "btn btn-lg btn-outline-light"

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -1,20 +1,25 @@
-= flash[:danger]
-h2
-  | Log in
-= form_with model: @user, url: user_session_path, local: true  do |f|
-  .field
-    = f.label :email
-    br
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  .field
-    = f.label :password
-    br
-    = f.password_field :password, autocomplete: "current-password"
-  - if devise_mapping.rememberable?
-    .field
-      = f.check_box :remember_me
-      = f.label :remember_me
-  .actions
-    = f.submit "Log in"
-
-= render "devise/shared/links"
+.user-login
+  h2.mt-3.text-center.text-light.rounded-pill.border.border-light
+    | ロ グ イ ン
+  = form_with model: @user, url: user_session_path, local: true do |f|
+    table.table.table-borderless.mt-5
+      tbody
+        tr
+          td.align-middle
+            span.text-light
+              |メールアドレス
+          td
+            = f.email_field :email, autofocus: true, autocomplete: "email", class:"form-control"
+        tr
+          td.align-middle
+            span.text-light
+              |パスワード
+          td
+            = f.password_field :password, autocomplete: "current-password", class:"form-control"
+    .row.justify-content-center
+      - if flash[:alert]
+        p.alert-info
+          i.fas.fa-exclamation-triangle
+          |#{flash[:alert]}
+    .row.justify-content-center
+      = f.submit "ログイン", class: "btn btn-lg btn-outline-light"

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -16,11 +16,14 @@
               |パスワード
           td
             = f.password_field :password, autocomplete: "current-password", class:"form-control"
+        tr
+          td
+          td.text-right
+            = link_to "パスワードをお忘れですか？", new_user_password_path, class:"text-info"
     .row.justify-content-center
       - if flash[:alert]
         p.alert-info
           i.fas.fa-exclamation-triangle
           |#{flash[:alert]}
-          |#{flash[:error]}
     .row.justify-content-center
       = f.submit "ログイン", class: "btn btn-lg btn-outline-light"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -17,9 +17,6 @@ html
         .col-sm-2.left-column
           = render 'shared/column', objects: @left_posts, count: @left_count
         .col-sm-8.main-column.position-absolute
-          .notifications
-            - flash.each do |key, value|
-              = content_tag(:div, value, class: key)
           = yield
         .col-sm-2.right-column
           = render 'shared/column', objects: @right_posts, count: @right_count

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,4 +70,7 @@ Rails.application.configure do
     authentication:       'plain',
     enable_starttls_auto: true
   }
+
+  # devise mailer settings
+  config.action_mailer.default_url_options = { host: ENV['AWS_TESTAD'] }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -105,5 +105,5 @@ Rails.application.configure do
   }
 
   # devise mailer settings
-  config.action_mailer.default_url_options = { host: "https://illuminationeon.com/" }
+  config.action_mailer.default_url_options = { host: "https://illuminationeon.com" }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -104,4 +104,6 @@ Rails.application.configure do
     enable_starttls_auto: true
   }
 
+  # devise mailer settings
+  config.action_mailer.default_url_options = { host: "https://illuminationeon.com/" }
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = ENV['GMAIL_ID']
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,6 +1,65 @@
 # Additional translations at https://github.com/heartcombo/devise/wiki/I18n
 
-ja:
+en:
   devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
     failure:
-      inactive: "有効なユーザーではありません。"
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      email_changed:
+        subject: "Email Changed"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again"
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,65 +1,6 @@
 # Additional translations at https://github.com/heartcombo/devise/wiki/I18n
 
-en:
+ja:
   devise:
-    confirmations:
-      confirmed: "Your email address has been successfully confirmed."
-      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
-      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
     failure:
-      already_authenticated: "You are already signed in."
-      inactive: "Your account is not activated yet."
-      invalid: "Invalid %{authentication_keys} or password."
-      locked: "Your account is locked."
-      last_attempt: "You have one more attempt before your account is locked."
-      not_found_in_database: "Invalid %{authentication_keys} or password."
-      timeout: "Your session expired. Please sign in again to continue."
-      unauthenticated: "You need to sign in or sign up before continuing."
-      unconfirmed: "You have to confirm your email address before continuing."
-    mailer:
-      confirmation_instructions:
-        subject: "Confirmation instructions"
-      reset_password_instructions:
-        subject: "Reset password instructions"
-      unlock_instructions:
-        subject: "Unlock instructions"
-      email_changed:
-        subject: "Email Changed"
-      password_change:
-        subject: "Password Changed"
-    omniauth_callbacks:
-      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
-      success: "Successfully authenticated from %{kind} account."
-    passwords:
-      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
-      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
-      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
-      updated: "Your password has been changed successfully. You are now signed in."
-      updated_not_active: "Your password has been changed successfully."
-    registrations:
-      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
-      signed_up: "Welcome! You have signed up successfully."
-      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
-      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
-      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
-      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
-      updated: "Your account has been updated successfully."
-      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again"
-    sessions:
-      signed_in: "Signed in successfully."
-      signed_out: "Signed out successfully."
-      already_signed_out: "Signed out successfully."
-    unlocks:
-      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
-      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
-      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
-  errors:
-    messages:
-      already_confirmed: "was already confirmed, please try signing in"
-      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
-      expired: "has expired, please request a new one"
-      not_found: "not found"
-      not_locked: "was not locked"
-      not_saved:
-        one: "1 error prohibited this %{resource} from being saved:"
-        other: "%{count} errors prohibited this %{resource} from being saved:"
+      inactive: "有効なユーザーではありません。"

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,65 @@
+# Additional translations at https://github.com/heartcombo/devise/wiki/I18n
+
+en:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      email_changed:
+        subject: "Email Changed"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again"
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,65 +1,12 @@
 # Additional translations at https://github.com/heartcombo/devise/wiki/I18n
 
-en:
+ja:
   devise:
-    confirmations:
-      confirmed: "Your email address has been successfully confirmed."
-      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
-      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
     failure:
-      already_authenticated: "You are already signed in."
-      inactive: "Your account is not activated yet."
-      invalid: "Invalid %{authentication_keys} or password."
-      locked: "Your account is locked."
-      last_attempt: "You have one more attempt before your account is locked."
-      not_found_in_database: "Invalid %{authentication_keys} or password."
-      timeout: "Your session expired. Please sign in again to continue."
-      unauthenticated: "You need to sign in or sign up before continuing."
-      unconfirmed: "You have to confirm your email address before continuing."
+      inactive: "有効なユーザーではありません。"
     mailer:
-      confirmation_instructions:
-        subject: "Confirmation instructions"
       reset_password_instructions:
-        subject: "Reset password instructions"
-      unlock_instructions:
-        subject: "Unlock instructions"
-      email_changed:
-        subject: "Email Changed"
-      password_change:
-        subject: "Password Changed"
-    omniauth_callbacks:
-      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
-      success: "Successfully authenticated from %{kind} account."
-    passwords:
-      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
-      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
-      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
-      updated: "Your password has been changed successfully. You are now signed in."
-      updated_not_active: "Your password has been changed successfully."
-    registrations:
-      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
-      signed_up: "Welcome! You have signed up successfully."
-      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
-      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
-      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
-      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
-      updated: "Your account has been updated successfully."
-      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again"
-    sessions:
-      signed_in: "Signed in successfully."
-      signed_out: "Signed out successfully."
-      already_signed_out: "Signed out successfully."
-    unlocks:
-      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
-      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
-      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+        subject: "【IlluminatioNeon】パスワード再発行申請のお知らせ"
   errors:
     messages:
-      already_confirmed: "was already confirmed, please try signing in"
-      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
-      expired: "has expired, please request a new one"
-      not_found: "not found"
-      not_locked: "was not locked"
-      not_saved:
-        one: "1 error prohibited this %{resource} from being saved:"
-        other: "%{count} errors prohibited this %{resource} from being saved:"
+      not_found: "は登録されていないようです。"


### PR DESCRIPTION
- 機能面
  - deviseのMailerを用い、データベースに登録されているアドレスがある際にメールを用いてパスワード問い合わせができるように。
  - 各ビューも他同様に合わせている。
  - form_forはform_withに変更している。
- デザイン面
  - デザインをワイヤーフレームに近づけている。